### PR TITLE
Correct actor and critic network initialization in benchmark files

### DIFF
--- a/s100lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py
+++ b/s100lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py
@@ -49,10 +49,10 @@ class CCMADDPG(object):
             self.epsilon_decay = epsilon_decay
         self.use_cuda = use_cuda and torch.cuda.is_available()
         self.target_tau = target_tau
-        self.actors = [ActorNetwork(self.state_dim, self.action_dim, self.actor_output_activation)] * self.n_agents
+        self.actors = [ActorNetwork(self.state_dim, self.action_dim, self.actor_output_activation) for _ in range(self.n_agents)]
         critic_state_dim = self.n_agents * self.state_dim
         critic_action_dim = self.n_agents * self.action_dim
-        self.critics = [CriticNetwork(critic_state_dim, critic_action_dim)] * 1
+        self.critics = [CriticNetwork(critic_state_dim, critic_action_dim) for _ in range(1)]
         # to ensure target network and learning network has the same weights
         self.actors_target = deepcopy(self.actors)
         self.critics_target = deepcopy(self.critics)

--- a/s100lre4e3CCM_MADRL_MECLambda5/Benchmarks_MADDPG.py
+++ b/s100lre4e3CCM_MADRL_MECLambda5/Benchmarks_MADDPG.py
@@ -49,10 +49,10 @@ class CCMADDPG(object):
             self.epsilon_decay = epsilon_decay
         self.use_cuda = use_cuda and torch.cuda.is_available()
         self.target_tau = target_tau
-        self.actors = [ActorNetwork(self.state_dim, self.action_dim, self.actor_output_activation)] * self.n_agents
+        self.actors = [ActorNetwork(self.state_dim, self.action_dim, self.actor_output_activation) for _ in range(self.n_agents)]
         critic_state_dim = self.n_agents * self.state_dim
         critic_action_dim = self.n_agents * self.action_dim
-        self.critics = [CriticNetwork(critic_state_dim, critic_action_dim)] * 1
+        self.critics = [CriticNetwork(critic_state_dim, critic_action_dim) for _ in range(1)]
         # to ensure target network and learning network has the same weights
         self.actors_target = deepcopy(self.actors)
         self.critics_target = deepcopy(self.critics)

--- a/s10lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py
+++ b/s10lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py
@@ -49,10 +49,10 @@ class CCMADDPG(object):
             self.epsilon_decay = epsilon_decay
         self.use_cuda = use_cuda and torch.cuda.is_available()
         self.target_tau = target_tau
-        self.actors = [ActorNetwork(self.state_dim, self.action_dim, self.actor_output_activation)] * self.n_agents
+        self.actors = [ActorNetwork(self.state_dim, self.action_dim, self.actor_output_activation) for _ in range(self.n_agents)]
         critic_state_dim = self.n_agents * self.state_dim
         critic_action_dim = self.n_agents * self.action_dim
-        self.critics = [CriticNetwork(critic_state_dim, critic_action_dim)] * 1
+        self.critics = [CriticNetwork(critic_state_dim, critic_action_dim) for _ in range(1)]
         # to ensure target network and learning network has the same weights
         self.actors_target = deepcopy(self.actors)
         self.critics_target = deepcopy(self.critics)


### PR DESCRIPTION
Updated the initialization of actor and critic networks across all benchmark experiments to use list comprehensions instead of list multiplication. This ensures each agent has its own independent network instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)