### PR TITLE
Fix nested loop variable shadowing issue in agent training

### DIFF
--- a/s100lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py
+++ b/s100lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py
@@ -225,11 +225,11 @@ class CCMADDPG(object):
                
         
         #different actors
-        for agent_id in range(self.n_agents): 
-            newactor_actions = [] 
+        for agent_id in range(self.n_agents):
+            newactor_actions = []
             # Calculate new actions for each agent
-            for agent_id in range(self.n_agents):
-                newactor_action_var = self.actors[agent_id](states_var[:, agent_id, :])
+            for agent_in in range(self.n_agents):
+                newactor_action_var = self.actors[agent_in](states_var[:, agent_in, :])
                 if self.use_cuda:
                     newactor_actions.append(newactor_action_var)#newactor_actions.append(newactor_action_var.data.cpu())
                 else:

--- a/s100lre4e3CCM_MADRL_MEC/CCM_MADRL.py
+++ b/s100lre4e3CCM_MADRL_MEC/CCM_MADRL.py
@@ -267,11 +267,11 @@ class CCM_MADDPG(object):
         
         
         #different actors
-        for agent_id in range(self.n_agents): 
-            newactor_actions = [] 
+        for agent_id in range(self.n_agents):
+            newactor_actions = []
             # Calculate new actions for each agent
-            for agent_id in range(self.n_agents):
-                newactor_action_var = self.actors[agent_id](states_var[:, agent_id, :])
+            for agent_in in range(self.n_agents):
+                newactor_action_var = self.actors[agent_in](states_var[:, agent_in, :])
                 if self.use_cuda:
                     newactor_actions.append(newactor_action_var)#newactor_actions.append(newactor_action_var.data.cpu())
                 else:

--- a/s100lre4e3CCM_MADRL_MECLambda5/Benchmarks_MADDPG.py
+++ b/s100lre4e3CCM_MADRL_MECLambda5/Benchmarks_MADDPG.py
@@ -225,11 +225,11 @@ class CCMADDPG(object):
                
         
         #different actors
-        for agent_id in range(self.n_agents): 
-            newactor_actions = [] 
+        for agent_id in range(self.n_agents):
+            newactor_actions = []
             # Calculate new actions for each agent
-            for agent_id in range(self.n_agents):
-                newactor_action_var = self.actors[agent_id](states_var[:, agent_id, :])
+            for agent_in in range(self.n_agents):
+                newactor_action_var = self.actors[agent_in](states_var[:, agent_in, :])
                 if self.use_cuda:
                     newactor_actions.append(newactor_action_var)#newactor_actions.append(newactor_action_var.data.cpu())
                 else:

--- a/s100lre4e3CCM_MADRL_MECLambda5/CCM_MADRL.py
+++ b/s100lre4e3CCM_MADRL_MECLambda5/CCM_MADRL.py
@@ -267,11 +267,11 @@ class CCM_MADDPG(object):
         
         
         #different actors
-        for agent_id in range(self.n_agents): 
-            newactor_actions = [] 
+        for agent_id in range(self.n_agents):
+            newactor_actions = []
             # Calculate new actions for each agent
-            for agent_id in range(self.n_agents):
-                newactor_action_var = self.actors[agent_id](states_var[:, agent_id, :])
+            for agent_in in range(self.n_agents):
+                newactor_action_var = self.actors[agent_in](states_var[:, agent_in, :])
                 if self.use_cuda:
                     newactor_actions.append(newactor_action_var)#newactor_actions.append(newactor_action_var.data.cpu())
                 else:

--- a/s10lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py
+++ b/s10lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py
@@ -225,11 +225,11 @@ class CCMADDPG(object):
                
         
         #different actors
-        for agent_id in range(self.n_agents): 
-            newactor_actions = [] 
+        for agent_id in range(self.n_agents):
+            newactor_actions = []
             # Calculate new actions for each agent
-            for agent_id in range(self.n_agents):
-                newactor_action_var = self.actors[agent_id](states_var[:, agent_id, :])
+            for agent_in in range(self.n_agents):
+                newactor_action_var = self.actors[agent_in](states_var[:, agent_in, :])
                 if self.use_cuda:
                     newactor_actions.append(newactor_action_var)#newactor_actions.append(newactor_action_var.data.cpu())
                 else:

--- a/s10lre4e3CCM_MADRL_MEC/CCM_MADRL.py
+++ b/s10lre4e3CCM_MADRL_MEC/CCM_MADRL.py
@@ -267,11 +267,11 @@ class CCM_MADDPG(object):
         
         
         #different actors
-        for agent_id in range(self.n_agents): 
-            newactor_actions = [] 
+        for agent_id in range(self.n_agents):
+            newactor_actions = []
             # Calculate new actions for each agent
-            for agent_id in range(self.n_agents):
-                newactor_action_var = self.actors[agent_id](states_var[:, agent_id, :])
+            for agent_in in range(self.n_agents):
+                newactor_action_var = self.actors[agent_in](states_var[:, agent_in, :])
                 if self.use_cuda:
                     newactor_actions.append(newactor_action_var)#newactor_actions.append(newactor_action_var.data.cpu())
                 else:


### PR DESCRIPTION
Changed inner loop variable from 'agent_id' to 'agent_in' in the train() method to avoid confusion with the outer loop variable. This fixes a variable shadowing bug that could cause incorrect agent action calculations during training.

Files affected:
- s10lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py
- s10lre4e3CCM_MADRL_MEC/CCM_MADRL.py
- s100lre4e3CCM_MADRL_MECLambda5/CCM_MADRL.py
- s100lre4e3CCM_MADRL_MECLambda5/Benchmarks_MADDPG.py
- s100lre4e3CCM_MADRL_MEC/CCM_MADRL.py
- s100lre4e3CCM_MADRL_MEC/Benchmarks_MADDPG.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)